### PR TITLE
Server not closing on unmatched requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea
 *.iml
+
+target/

--- a/src/main/java/com/github/jenspiegsa/mockitoextension/WireMockExtension.java
+++ b/src/main/java/com/github/jenspiegsa/mockitoextension/WireMockExtension.java
@@ -91,12 +91,12 @@ public class WireMockExtension implements BeforeEachCallback, AfterEachCallback 
 
 	@Override
 	public void afterEach(final ExtensionContext context) {
-		checkForUnmatchedRequests(context);
 		final List<WireMockServer> servers = serversByTestId.get(context.getUniqueId());
-
 		if (servers != null) {
 			servers.forEach(WireMockServer::stop);
 		}
+
+		checkForUnmatchedRequests(context);
 	}
 
 	private void checkForUnmatchedRequests(final ExtensionContext context) {


### PR DESCRIPTION
Hi,
There is a small non-blocking, but oftentimes disturbing, bug that appears when there is an unmatched request during a test: an unmatched request will throw an exception in the `checkForUnmatchedRequests()` method, which prevents the stopping of the servers. 

I was not able to thoroughly test this bugfix, since it would require to test that the before each callback in the extension does not throw a `FatalStartupException` in a test following a test containing a request mismatch call. So I guess we can say that the current tests should do the job :) 